### PR TITLE
Hint on using env variables to configure the application

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ The location of the config file can be set using e cmdline flag or environment v
 NUTS_CONFIGFILE=./server.config.yaml ./monitor
 ```
 
+You can also configure the application using environment variables (capitalize all keys and prefix with `NUTS_`):
+
+```shell
+NUTS_NUTSNODEADDR=http://nuts-node-address:1323 ./monitor
+```
+
 When running in Docker without a config file mounted at `/app/server.config.yaml` it will use the default configuration or you can change the command parameters.
 
 The `nutsnodeapikeyfile` config parameter should point to a PEM encoded private key file. The corresponding public key should be configured on the Nuts node in SSH authorized keys format.

--- a/api/api.go
+++ b/api/api.go
@@ -53,7 +53,7 @@ func (w Wrapper) CheckHealth(ctx context.Context, _ CheckHealthRequestObject) (C
 		Status: DOWN,
 	}
 
-	if w.Config.NutsNodeAddress != "" {
+	if w.Config.NutsNodeAddr != "" {
 		h, err := w.Client.CheckHealth(ctx)
 		if err != nil {
 			var errString interface{} = err.Error()

--- a/client/client.go
+++ b/client/client.go
@@ -31,7 +31,7 @@ type HTTPClient struct {
 }
 
 func (hb HTTPClient) client() ClientInterface {
-	response, err := NewClientWithResponses(hb.Config.NutsNodeAddress, WithHTTPClient(MustCreateHTTPClient(hb.Config)))
+	response, err := NewClientWithResponses(hb.Config.NutsNodeAddr, WithHTTPClient(MustCreateHTTPClient(hb.Config)))
 	if err != nil {
 		panic(err)
 	}

--- a/client/integration_test.go
+++ b/client/integration_test.go
@@ -31,7 +31,7 @@ import (
 func TestClient_CheckHealth(t *testing.T) {
 	ts := test.BasicTestNode(t)
 
-	client := HTTPClient{Config: config.Config{NutsNodeAddress: ts.URL()}}
+	client := HTTPClient{Config: config.Config{NutsNodeAddr: ts.URL()}}
 	resp, err := client.CheckHealth(context.Background())
 	if err != nil {
 		t.Fatalf("Failed to get correct response: %v", err)
@@ -54,7 +54,7 @@ func TestClient_Diagnostics(t *testing.T) {
 		w.Write(dBytes)
 	})
 
-	client := HTTPClient{Config: config.Config{NutsNodeAddress: ts.URL()}}
+	client := HTTPClient{Config: config.Config{NutsNodeAddr: ts.URL()}}
 	resp, err := client.Diagnostics(context.Background())
 	if err != nil {
 		t.Fatalf("Failed to get correct response: %v", err)

--- a/config/config.go
+++ b/config/config.go
@@ -46,13 +46,13 @@ const defaultNutsNodeAddress = "http://localhost:1323"
 
 func defaultConfig() Config {
 	return Config{
-		NutsNodeAddress: defaultNutsNodeAddress,
+		NutsNodeAddr: defaultNutsNodeAddress,
 	}
 }
 
 type Config struct {
-	// NutsNodeAddress contains the address of the Nuts node. It's also used in the aud field when API security is enabled
-	NutsNodeAddress string `koanf:"nutsnodeaddr"`
+	// NutsNodeAddr contains the address of the Nuts node. It's also used in the aud field when API security is enabled
+	NutsNodeAddr string `koanf:"nutsnodeaddr"`
 	// NutsNodeAPIKeyFile points to the private key used to sign JWTs. If empty Nuts node API security is not enabled
 	NutsNodeAPIKeyFile string `koanf:"nutsnodeapikeyfile"`
 	// NutsNodeAPIUser contains the API key user that will go into the iss field. It must match the user with the public key from the authorized_keys file in the Nuts node

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -30,5 +30,5 @@ func TestConfig_loadConfig(t *testing.T) {
 
 	cfg := LoadConfig()
 
-	assert.Equal(t, "http://example.com", cfg.NutsNodeAddress)
+	assert.Equal(t, "http://example.com", cfg.NutsNodeAddr)
 }


### PR DESCRIPTION
Also renamed `NutsNodeAddress` to `NutsNodeAddr`, because config logging makes things confusing, since in the actual config `address` is abbrv to `addr`;

```
stable-stable-nuts-monitor-1  | ========== CONFIG: ==========
stable-stable-nuts-monitor-1  | {
stable-stable-nuts-monitor-1  |   "NutsNodeAddress": "http://stable-nuts-node:80",
stable-stable-nuts-monitor-1  |   "NutsNodeAPIKeyFile": "",
stable-stable-nuts-monitor-1  |   "NutsNodeAPIUser": "",
stable-stable-nuts-monitor-1  |   "NutsNodeAPIAudience": "",
stable-stable-nuts-monitor-1  |   "ApiKey": null
stable-stable-nuts-monitor-1  | }
stable-stable-nuts-monitor-1  | ========= END CONFIG =========
```