### PR TITLE
added screen that shows transaction graph per hour, day and month

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -23,6 +23,8 @@ import (
 	"nuts-foundation/nuts-monitor/client"
 	"nuts-foundation/nuts-monitor/client/diagnostics"
 	"nuts-foundation/nuts-monitor/config"
+	"nuts-foundation/nuts-monitor/data"
+	"time"
 )
 
 var _ StrictServerInterface = (*Wrapper)(nil)
@@ -33,8 +35,9 @@ const (
 )
 
 type Wrapper struct {
-	Config config.Config
-	Client client.HTTPClient
+	Config    config.Config
+	Client    client.HTTPClient
+	DataStore *data.Store
 }
 
 func (w Wrapper) Diagnostics(ctx context.Context, _ DiagnosticsRequestObject) (DiagnosticsResponseObject, error) {
@@ -96,4 +99,37 @@ func (w Wrapper) NetworkTopology(ctx context.Context, _ NetworkTopologyRequestOb
 	}
 
 	return NetworkTopology200JSONResponse(networkTopology), nil
+}
+
+func (w Wrapper) GetWebTransactionsAggregated(ctx context.Context, _ GetWebTransactionsAggregatedRequestObject) (GetWebTransactionsAggregatedResponseObject, error) {
+	// get data from the store
+	dataPoints := w.DataStore.GetTransactions()
+
+	// convert the data points to the response object
+	response := AggregatedTransactions{}
+	// loop over the 3 categories of data points
+	// for each category, loop over the data points and add them to the correct category in the response object
+	for _, dp := range dataPoints[0] {
+		response.Hourly = append(response.Hourly, DataPoint{
+			Timestamp: int(dp.Timestamp.Unix()),
+			Label:     dp.Timestamp.Format(time.RFC3339),
+			Value:     int(dp.Count),
+		})
+	}
+	for _, dp := range dataPoints[1] {
+		response.Daily = append(response.Daily, DataPoint{
+			Timestamp: int(dp.Timestamp.Unix()),
+			Label:     dp.Timestamp.Format(time.RFC3339),
+			Value:     int(dp.Count),
+		})
+	}
+	for _, dp := range dataPoints[2] {
+		response.Monthly = append(response.Monthly, DataPoint{
+			Timestamp: int(dp.Timestamp.Unix()),
+			Label:     dp.Timestamp.Format(time.RFC3339),
+			Value:     int(dp.Count),
+		})
+	}
+
+	return GetWebTransactionsAggregated200JSONResponse(response), nil
 }

--- a/api/api.go
+++ b/api/api.go
@@ -110,26 +110,22 @@ func (w Wrapper) GetWebTransactionsAggregated(ctx context.Context, _ GetWebTrans
 	// loop over the 3 categories of data points
 	// for each category, loop over the data points and add them to the correct category in the response object
 	for _, dp := range dataPoints[0] {
-		response.Hourly = append(response.Hourly, DataPoint{
-			Timestamp: int(dp.Timestamp.Unix()),
-			Label:     dp.Timestamp.Format(time.RFC3339),
-			Value:     int(dp.Count),
-		})
+		response.Hourly = append(response.Hourly, toDataPoint(dp))
 	}
 	for _, dp := range dataPoints[1] {
-		response.Daily = append(response.Daily, DataPoint{
-			Timestamp: int(dp.Timestamp.Unix()),
-			Label:     dp.Timestamp.Format(time.RFC3339),
-			Value:     int(dp.Count),
-		})
+		response.Daily = append(response.Daily, toDataPoint(dp))
 	}
 	for _, dp := range dataPoints[2] {
-		response.Monthly = append(response.Monthly, DataPoint{
-			Timestamp: int(dp.Timestamp.Unix()),
-			Label:     dp.Timestamp.Format(time.RFC3339),
-			Value:     int(dp.Count),
-		})
+		response.Monthly = append(response.Monthly, toDataPoint(dp))
 	}
 
 	return GetWebTransactionsAggregated200JSONResponse(response), nil
+}
+
+func toDataPoint(dp data.DataPoint) DataPoint {
+	return DataPoint{
+		Timestamp: int(dp.Timestamp.Unix()),
+		Label:     dp.Timestamp.Format(time.RFC3339),
+		Value:     int(dp.Count),
+	}
 }

--- a/api/api.yaml
+++ b/api/api.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  title: Nuts Registry Admin API
+  title: Nuts Monitor API
   version: 1.0.0
 
 paths:
@@ -44,8 +44,47 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/NetworkTopology"
+  /web/transactions/aggregated:
+    get:
+      summary: "Returns the transactions aggregated by time"
+      description: >
+        Returns the transactions aggregated by time. It contains three sets of data points:
+        - an interval of 1 hour with a resolution of 1 minute
+        - an interval of 1 day with a resolution of 1 hour
+        - an interval of 1 month with a resolution of 1 day
+        operationId: aggregatedTransactions
+      responses:
+          200:
+            description: "Aggregated transactions data"
+            content:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/AggregatedTransactions"
 components:
   schemas:
+    AggregatedTransactions:
+      type: object
+      description: "Aggregated transactions data"
+      required:
+        - hourly
+        - daily
+        - monthly
+      properties:
+        hourly:
+          type: array
+          description: "Aggregated transactions data for the last hour"
+          items:
+            $ref: "#/components/schemas/DataPoint"
+        daily:
+          type: array
+          description: "Aggregated transactions data for the last day"
+          items:
+            $ref: "#/components/schemas/DataPoint"
+        monthly:
+          type: array
+          description: "Aggregated transactions data for the last month"
+          items:
+            $ref: "#/components/schemas/DataPoint"
     CheckHealthResponse:
       required:
         - status
@@ -59,6 +98,23 @@ components:
           description: Map of the performed health checks and their results.
           additionalProperties:
             $ref: "#/components/schemas/HealthCheckResult"
+    DataPoint:
+        type: object
+        description: "Data point"
+        required:
+            - timestamp
+            - label
+            - value
+        properties:
+          timestamp:
+            type: integer
+            description: "time of the data point formatted as unix timestamp"
+          label:
+            type: string
+            description: "time of the data point formatted as RFC3339"
+          value:
+            type: integer
+            description: "number of transactions at the given timestamp"
     Diagnostics:
       required:
         - network

--- a/api/api.yaml
+++ b/api/api.yaml
@@ -114,7 +114,7 @@ components:
             description: "time of the data point formatted as RFC3339"
           value:
             type: integer
-            description: "number of transactions at the given timestamp"
+            description: "number of transactions between the given timestamp and the next timestamp"
     Diagnostics:
       required:
         - network

--- a/client/client.go
+++ b/client/client.go
@@ -150,3 +150,27 @@ func (hb HTTPClient) DIDDocument(ctx context.Context, did string) (*vdr.DIDResol
 	}
 	return nil, fmt.Errorf("received incorrect response from node: %s", string(result.Body))
 }
+
+// ListTransactions returns transactions in a certain range according to LC value
+func (hb HTTPClient) ListTransactions(ctx context.Context, start int, end int) ([]string, error) {
+	var transactions []string
+
+	response, err := hb.networkClient().ListTransactions(ctx, &network.ListTransactionsParams{
+		Start: &start,
+		End:   &end,
+	})
+	if err != nil {
+		return transactions, err
+	}
+	if err := TestResponseCode(http.StatusOK, response); err != nil {
+		return transactions, err
+	}
+	parsedResponse, err := network.ParseListTransactionsResponse(response)
+	if err != nil {
+		return transactions, err
+	}
+	if parsedResponse.JSON200 != nil {
+		return *parsedResponse.JSON200, nil
+	}
+	return transactions, nil
+}

--- a/codegen/network-config.yaml
+++ b/codegen/network-config.yaml
@@ -6,3 +6,4 @@ generate:
 output-options:
   include-tags:
     - diagnostics
+    - transactions

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,11 @@
+Things todo:
+
+Data format
+- map of DID to its controller (cache)
+- map of controller to list of (type, count)
+- map of type to list of (time, count)
+- sliding window (3 times)
+
+Process
+- run at startup
+- listen to nats

--- a/data/store.go
+++ b/data/store.go
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2023 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package data
+
+import (
+	"context"
+	"time"
+)
+
+// Store is an in-memory store that contains a mapping from transaction signer to its controller.
+// It also contains three sliding windows with length and resolution of: (1 hour, 1 minute), (1 day, 1 hour), (30 days, 1 day).
+// A transaction can be added, the store will resolve the signer and the controller of the signer.
+type Store struct {
+	mapping        map[string]string
+	slidingWindows []slidingWindow
+}
+
+func NewStore() *Store {
+	s := &Store{
+		mapping: make(map[string]string),
+		slidingWindows: []slidingWindow{
+			{
+				resolution:       time.Minute,
+				length:           time.Hour,
+				evictionInterval: time.Second,
+			},
+			{
+				resolution:       time.Hour,
+				length:           24 * time.Hour,
+				evictionInterval: time.Minute,
+			},
+			{
+				resolution:       24 * time.Hour,
+				length:           30 * 24 * time.Hour,
+				evictionInterval: time.Minute,
+			},
+		},
+	}
+
+	// initialize all windows with empty dataPoints using the init function
+	for i := range s.slidingWindows {
+		s.slidingWindows[i].init()
+	}
+
+	return s
+}
+
+// Start starts the sliding windows
+func (s *Store) Start(ctx context.Context) {
+	for i := range s.slidingWindows {
+		s.slidingWindows[i].start(ctx)
+	}
+}
+
+// Add a transaction to the sliding windows and resolve the controller of the signer
+func (s *Store) Add(transaction Transaction) {
+	// first add the transaction to the sliding windows
+	for i := range s.slidingWindows {
+		s.slidingWindows[i].addCount(transaction.SigTime)
+	}
+
+	// todo: resolve the controller of the signer
+}
+
+// GetTransactions returns the transactions of the sliding windows
+// The smallest resolution is first, the largest resolution is last
+func (s *Store) GetTransactions() [3][]DataPoint {
+	var transactions [3][]DataPoint
+
+	for i, window := range s.slidingWindows {
+		transactions[i] = window.dataPoints
+	}
+
+	return transactions
+}

--- a/data/transaction.go
+++ b/data/transaction.go
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2023 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package data
+
+import (
+	"errors"
+	"github.com/lestrrat-go/jwx/jws"
+	"strings"
+	"time"
+)
+
+// ErrInvalidSigner is returned when the signer is not a valid DID signer
+var ErrInvalidSigner = errors.New("invalid signer")
+
+// ErrNoSigTime is returned when the transaction does not contain a sigt field
+var ErrNoSigTime = errors.New("no sigt field")
+
+// Transaction represents a Nuts transaction.
+// It is parsed from a JWS token. It does not check the signature.
+type Transaction struct {
+	// Signer is extracted from the key used to sign the transaction
+	Signer string
+	// SigTime is the signature time in seconds since the Unix epoch
+	SigTime time.Time
+}
+
+func FromJWS(transaction string) (*Transaction, error) {
+	// we use the lestrrat-go/jwx library to parse the JWS
+	jwsToken, err := jws.ParseString(transaction)
+	if err != nil {
+		return nil, err
+	}
+
+	// first extract the signature time from the "sigt" field
+	// the "sigt" field is a Unix Timestamp in seconds
+	// we convert it to an int64
+	sigt, ok := jwsToken.Signatures()[0].ProtectedHeaders().Get("sigt")
+	if !ok {
+		return nil, ErrNoSigTime
+	}
+	// parse the sigt string value to time field
+	sigTime := time.Unix(int64(sigt.(float64)), 0)
+
+	// the signer can either be extracted from the "kid" header or from the embedded key
+	// we first try to extract it from the "kid" header
+	signer, ok := jwsToken.Signatures()[0].ProtectedHeaders().Get("kid")
+	if ok {
+		// the kid is a combination of DID and key ID, we only want the DID part
+		// the DID is the part before the first #
+		// example: did:nuts:0x1234567890abcdef#key-1 -> did:nuts:0x1234567890abcdef
+		// check if # is contained in the string, return an error if not
+		index := strings.Index(signer.(string), "#")
+		if index == -1 {
+			return nil, ErrInvalidSigner
+		}
+		return &Transaction{Signer: signer.(string)[:index], SigTime: sigTime}, nil
+	}
+
+	// if the "kid" header is not present, we try to extract the signer from the embedded key
+	// the embedded key is a JWK, we extract the "kid" header from it
+	// the "kid" header is a combination of DID and key ID, we only want the DID part
+	// the DID is the part before the first #
+	// example: did:nuts:0x1234567890abcdef#key-1 -> did:nuts:0x1234567890abcdef
+	jwk := jwsToken.Signatures()[0].ProtectedHeaders().JWK()
+	if jwk != nil {
+		kid := jwk.KeyID()
+		index := strings.Index(kid, "#")
+		if index == -1 {
+			return nil, ErrInvalidSigner
+		}
+		return &Transaction{Signer: kid[:index], SigTime: sigTime}, nil
+	}
+
+	return &Transaction{}, nil
+}

--- a/data/transaction_test.go
+++ b/data/transaction_test.go
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2023 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+package data
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+// ExampleJWS contains a correct transaction in condensed JWS format with a jwk field
+const ExampleJWS = "eyJhbGciOiJFUzI1NiIsImNyaXQiOlsic2lndCIsInZlciIsInByZXZzIiwiandrIl0sImN0eSI6ImFwcGxpY2F0aW9uL2RpZCtqc29uIiwiandrIjp7ImNydiI6IlAtMjU2Iiwia2lkIjoiZGlkOm51dHM6Q29yMzI4SjUxaE54U3V5RXVCZ2FWdVZuUXBFZ0tzOTFzTUpHYVB1M0I2SnIjcjNDM25kWHFMT0YzWkpCTkh5SVM4SFEzSjRVQmlKRGplQTRGREFRSk51OCIsImt0eSI6IkVDIiwieCI6IlpvMTRYR0pwRzIwSXdYUmFINGhjZ2p0bXUzTHF6dnNoUUlBTTZIWXZJN1UiLCJ5IjoibVJrOTZkRjVSd05Zd0tPUGxncTVxeUtoQUhkQ0UyeHM2bHFJaWtndGJJTSJ9LCJsYyI6MCwicHJldnMiOltdLCJzaWd0IjoxNjUzOTg2MTMwLCJ2ZXIiOjF9.Y2UxOTI3ZTQ1NTdjNDNmMmM1YWVkYzg1OWI4OTg3ZmY2NmI3ZDk3YjhmZmVhZDJkNjEyZDE1ZjNkNTIwMmJlOQ.PEZyffKoWPliezsUlfAm7cdcHTDCImwa5w6inVxC8QQg9swJM3ozjZEV2b3_DzOVDpN7jecvb1WeIf7PDMHTKQ"
+
+// ExampleJWS2 contains a correct transaction in condensed JWS format with a kid field
+const ExampleJWS2 = "eyJhbGciOiJFUzI1NiIsImNyaXQiOlsic2lndCIsInZlciIsInByZXZzIiwia2lkIl0sImN0eSI6ImFwcGxpY2F0aW9uL2RpZCtqc29uIiwia2lkIjoiZGlkOm51dHM6OWJXOFZoVmsyazRXNXAxNVpmVER0cFFEYVNrNm9MNnlhR0JaenU3ZzI5UFojZjdRdDcyVlRIZzIybC0tVmZ2VWZQTkR0V0ZfWWxENmFDTUotQmdvS3l4USIsImxjIjoxMCwicHJldnMiOlsiYjA2OGRkMjc0NDFjMDBkNzU1MTdjYjUwZmJhMjIyYjczZjU5NDFlZGY4ZDNmNGQxMzk2NjBjNDkyZTZkNmZkNyJdLCJzaWd0IjoxNjU0MjQ4OTU4LCJ2ZXIiOjF9.NDBmMmY0NGYxNDUwYjBiYzE2ZGYxMzYyMzZmM2I0MDkzZDc3NTEyM2IyZGM5YWFjMzg3YzJmZGMxYzIyYTliZA.1Ak130yrjlqEGgg3HcVm1JB0iEOlnxOhIGojo9icthyg50h72ByRzKg4Pa7oWnuKH4JnIzlZXkPH0vvC6BL2Bw"
+
+// ExampleJWS3 contains a transaction without a sigtime field
+const ExampleJWS3 = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+
+// ExampleJWS4 contains a transaction with an incorrect kid field
+const ExampleJWS4 = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImRpZDpudXRzOmFiY2RlZmcxMjM0NSJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.p3sW4cvesjhCCS05Uwhow12WFjH2fGKAQH5wmy5MdCQ"
+
+// ExampleJWS5 contains a transaction without key fields
+const ExampleJWS5 = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsInNpZ3QiOjEwfQ.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.NPkBysCGI47ey7RiDi_zPl9IxN34t3Kdk1Lpw3Dzzok"
+
+func TestFromJWS(t *testing.T) {
+	t.Run("extract transaction from a valid JWS with a jwk field", func(t *testing.T) {
+		transaction, err := FromJWS(ExampleJWS)
+
+		require.NoError(t, err)
+		assert.NotNil(t, transaction)
+		assert.Equal(t, time.Unix(1653986130, 0), transaction.SigTime)
+	})
+
+	t.Run("extract transaction from a valid JWS without a jwk field", func(t *testing.T) {
+		transaction, err := FromJWS(ExampleJWS2)
+
+		require.NoError(t, err)
+		assert.NotNil(t, transaction)
+	})
+	t.Run("extract transaction from a valid JWS without a jwk field and without a kid field", func(t *testing.T) {
+		transaction, err := FromJWS(ExampleJWS5)
+
+		require.NoError(t, err)
+		assert.NotNil(t, transaction)
+	})
+	t.Run("extract transaction from a valid JWS without a sigt field", func(t *testing.T) {
+		transaction, err := FromJWS(ExampleJWS3)
+
+		assert.Error(t, ErrNoSigTime, err)
+		assert.Nil(t, transaction)
+	})
+	t.Run("extract transaction from a JWS with an incorrect kid field", func(t *testing.T) {
+		transaction, err := FromJWS(ExampleJWS4)
+
+		assert.Error(t, err)
+		assert.Nil(t, transaction)
+	})
+}

--- a/data/window.go
+++ b/data/window.go
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2023 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package data
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"time"
+)
+
+type DataPoint struct {
+	Timestamp time.Time
+	Count     uint32
+}
+
+type slidingWindow struct {
+	resolution       time.Duration
+	length           time.Duration
+	evictionInterval time.Duration
+	mutex            sync.Mutex
+	dataPoints       []DataPoint
+}
+
+// init fill the dataPoints slice with DataPoints
+func (s *slidingWindow) init() {
+	s.dataPoints = make([]DataPoint, s.maxLength())
+
+	now := time.Now().Truncate(s.resolution)
+
+	for i := len(s.dataPoints) - 1; i >= 0; i-- {
+		s.dataPoints[i] = DataPoint{
+			Timestamp: now.Truncate(s.resolution).Add(time.Duration(i-len(s.dataPoints)+1) * s.resolution),
+			Count:     0,
+		}
+	}
+}
+
+func (s *slidingWindow) start(ctx context.Context) {
+	done := ctx.Done()
+
+	go func() {
+		ticker := time.NewTicker(s.evictionInterval)
+
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				s.slide()
+			}
+		}
+	}()
+}
+
+// maxLength calculates the maximum number of dataPoints in the sliding window
+func (s *slidingWindow) maxLength() int {
+	return int(s.length / s.resolution)
+}
+
+// slide removes dataPoints older than length
+func (s *slidingWindow) slide() {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	now := time.Now().Truncate(s.resolution)
+
+	cutoff := -1
+	for j := len(s.dataPoints) - 1; j >= 0; j-- {
+		if s.dataPoints[j].Timestamp.Before(now.Add(-s.length)) {
+			cutoff = j + 1
+			break
+		}
+	}
+
+	if cutoff == -1 {
+		return
+	}
+
+	// create a new slice with length equal to maxLength and fill it with the dataPoints that are not older than length
+	newSet := make([]DataPoint, s.maxLength())
+
+	copy(newSet, s.dataPoints[cutoff:])
+
+	// fill the remainder of the slice with new DataPoints, the last dataPoint should be time.Now().Truncate(s.resolution)
+	// each dataPoint before that should be time.Now().Truncate(s.resolution).Add(-s.resolution)
+	for i := len(newSet) - 1; i > cutoff; i-- {
+		newSet[i] = DataPoint{
+			Timestamp: now.Truncate(s.resolution).Add(time.Duration(i-len(newSet)+1) * s.resolution),
+			Count:     0,
+		}
+	}
+	s.dataPoints = newSet
+}
+
+// addCount adds +1 to the DataPoint at the correct moment
+func (s *slidingWindow) addCount(at time.Time) {
+	// first we truncate the at time to the correct resolution
+	at = at.Truncate(s.resolution)
+
+	// then we check if the at time is in the sliding window
+	if at.Before(time.Now().Add(-s.length)) {
+		// the at time is before the sliding window, we ignore it
+		return
+	}
+
+	// add the Count to the correct DataPoint
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	for i, dataPoint := range s.dataPoints {
+		if dataPoint.Timestamp == at {
+			s.dataPoints[i].Count++
+			return
+		}
+	}
+
+	// no DataPoint found, create a new one
+	s.dataPoints = append(s.dataPoints, DataPoint{
+		Timestamp: at,
+		Count:     1,
+	})
+
+	// sort the dataPoints
+	sort.Slice(s.dataPoints, func(i, j int) bool {
+		return s.dataPoints[i].Timestamp.Before(s.dataPoints[j].Timestamp)
+	})
+
+	return
+}

--- a/data/window_test.go
+++ b/data/window_test.go
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2023 Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package data
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestSlidingWindow_addCount(t *testing.T) {
+	t.Run("adds a new DataPoint", func(t *testing.T) {
+		window := slidingWindow{
+			resolution: time.Second,
+			length:     time.Second * 10,
+		}
+
+		window.addCount(time.Now())
+
+		assert.Len(t, window.dataPoints, 1)
+	})
+
+	t.Run("increases Count of existing DataPoint", func(t *testing.T) {
+		now := time.Now().Truncate(time.Second)
+		window := slidingWindow{
+			resolution: time.Second,
+			length:     time.Second * 10,
+			dataPoints: []DataPoint{
+				{Timestamp: now, Count: 1},
+			},
+		}
+
+		window.addCount(now)
+
+		assert.Len(t, window.dataPoints, 1)
+		assert.Equal(t, uint32(2), window.dataPoints[0].Count)
+	})
+}
+
+func TestSlidingWindow_slide(t *testing.T) {
+	t.Run("removes dataPoints older than length", func(t *testing.T) {
+		now := time.Now().Truncate(time.Second)
+		slightlyOlder := now.Add(-time.Millisecond)
+		window := slidingWindow{
+			resolution: time.Second,
+			length:     time.Second * 10,
+			dataPoints: []DataPoint{
+				{Timestamp: slightlyOlder.Add(time.Second * -10), Count: 1},
+				{Timestamp: now.Add(time.Second * -9), Count: 1},
+				{Timestamp: now.Add(time.Second * -8), Count: 1},
+			},
+		}
+
+		window.slide()
+
+		assert.Len(t, window.dataPoints, 10)
+		assert.Equal(t, now, window.dataPoints[9].Timestamp)
+		assert.Equal(t, uint32(0), window.dataPoints[9].Count)
+		assert.Equal(t, now.Add(time.Second*-1), window.dataPoints[8].Timestamp)
+		assert.Equal(t, uint32(0), window.dataPoints[8].Count)
+		assert.Equal(t, now.Add(time.Second*-2), window.dataPoints[7].Timestamp)
+		assert.Equal(t, uint32(0), window.dataPoints[7].Count)
+		assert.Equal(t, now.Add(time.Second*-3), window.dataPoints[6].Timestamp)
+		assert.Equal(t, uint32(0), window.dataPoints[6].Count)
+		assert.Equal(t, now.Add(time.Second*-4), window.dataPoints[5].Timestamp)
+		assert.Equal(t, uint32(0), window.dataPoints[5].Count)
+		assert.Equal(t, now.Add(time.Second*-5), window.dataPoints[4].Timestamp)
+		assert.Equal(t, uint32(0), window.dataPoints[4].Count)
+		assert.Equal(t, now.Add(time.Second*-6), window.dataPoints[3].Timestamp)
+		assert.Equal(t, uint32(0), window.dataPoints[3].Count)
+		assert.Equal(t, now.Add(time.Second*-7), window.dataPoints[2].Timestamp)
+		assert.Equal(t, uint32(0), window.dataPoints[2].Count)
+		assert.Equal(t, now.Add(time.Second*-8), window.dataPoints[1].Timestamp)
+		assert.Equal(t, uint32(1), window.dataPoints[1].Count)
+		assert.Equal(t, now.Add(time.Second*-9), window.dataPoints[0].Timestamp)
+		assert.Equal(t, uint32(1), window.dataPoints[0].Count)
+	})
+}
+
+func TestSlidingWindow_init(t *testing.T) {
+	t.Run("an empty window is filled with empty dataPoints", func(t *testing.T) {
+		window := slidingWindow{
+			resolution: time.Second,
+			length:     time.Second * 10,
+		}
+
+		window.init()
+
+		assert.Len(t, window.dataPoints, 10)
+	})
+}
+
+func TestSlidingWindow_start(t *testing.T) {
+	t.Run("slides periodically", func(t *testing.T) {
+		window := slidingWindow{
+			resolution:       time.Second,
+			length:           time.Second,
+			evictionInterval: time.Millisecond,
+			dataPoints: []DataPoint{
+				{Timestamp: time.Now().Truncate(time.Second).Add(-2 * time.Second), Count: 1},
+			},
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		window.start(ctx)
+
+		time.Sleep(time.Millisecond * 10)
+
+		assert.Len(t, window.dataPoints, 1)
+		assert.Equal(t, uint32(0), window.dataPoints[0].Count)
+	})
+}

--- a/data/window_test.go
+++ b/data/window_test.go
@@ -21,20 +21,24 @@ package data
 import (
 	"context"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
 )
 
-func TestSlidingWindow_addCount(t *testing.T) {
+func TestSlidingWindow_AddCount(t *testing.T) {
 	t.Run("adds a new DataPoint", func(t *testing.T) {
+		now := time.Now()
+
 		window := slidingWindow{
 			resolution: time.Second,
 			length:     time.Second * 10,
 		}
 
-		window.addCount(time.Now())
+		window.AddCount(now)
 
-		assert.Len(t, window.dataPoints, 1)
+		assert.Len(t, window.dataPoints, 10)
+		assert.Equal(t, now.Truncate(time.Second), window.dataPoints[9].Timestamp)
 	})
 
 	t.Run("increases Count of existing DataPoint", func(t *testing.T) {
@@ -47,7 +51,7 @@ func TestSlidingWindow_addCount(t *testing.T) {
 			},
 		}
 
-		window.addCount(now)
+		window.AddCount(now)
 
 		assert.Len(t, window.dataPoints, 1)
 		assert.Equal(t, uint32(2), window.dataPoints[0].Count)
@@ -70,61 +74,73 @@ func TestSlidingWindow_slide(t *testing.T) {
 
 		window.slide()
 
-		assert.Len(t, window.dataPoints, 10)
-		assert.Equal(t, now, window.dataPoints[9].Timestamp)
-		assert.Equal(t, uint32(0), window.dataPoints[9].Count)
-		assert.Equal(t, now.Add(time.Second*-1), window.dataPoints[8].Timestamp)
-		assert.Equal(t, uint32(0), window.dataPoints[8].Count)
-		assert.Equal(t, now.Add(time.Second*-2), window.dataPoints[7].Timestamp)
-		assert.Equal(t, uint32(0), window.dataPoints[7].Count)
-		assert.Equal(t, now.Add(time.Second*-3), window.dataPoints[6].Timestamp)
-		assert.Equal(t, uint32(0), window.dataPoints[6].Count)
-		assert.Equal(t, now.Add(time.Second*-4), window.dataPoints[5].Timestamp)
-		assert.Equal(t, uint32(0), window.dataPoints[5].Count)
-		assert.Equal(t, now.Add(time.Second*-5), window.dataPoints[4].Timestamp)
-		assert.Equal(t, uint32(0), window.dataPoints[4].Count)
-		assert.Equal(t, now.Add(time.Second*-6), window.dataPoints[3].Timestamp)
-		assert.Equal(t, uint32(0), window.dataPoints[3].Count)
-		assert.Equal(t, now.Add(time.Second*-7), window.dataPoints[2].Timestamp)
-		assert.Equal(t, uint32(0), window.dataPoints[2].Count)
-		assert.Equal(t, now.Add(time.Second*-8), window.dataPoints[1].Timestamp)
-		assert.Equal(t, uint32(1), window.dataPoints[1].Count)
+		assert.Len(t, window.dataPoints, 2)
 		assert.Equal(t, now.Add(time.Second*-9), window.dataPoints[0].Timestamp)
 		assert.Equal(t, uint32(1), window.dataPoints[0].Count)
+		assert.Equal(t, now.Add(time.Second*-8), window.dataPoints[1].Timestamp)
+		assert.Equal(t, uint32(1), window.dataPoints[1].Count)
 	})
 }
 
-func TestSlidingWindow_init(t *testing.T) {
-	t.Run("an empty window is filled with empty dataPoints", func(t *testing.T) {
+func TestSlidingWindow_consolidate(t *testing.T) {
+	t.Run("it fills up a window to the length", func(t *testing.T) {
 		window := slidingWindow{
 			resolution: time.Second,
 			length:     time.Second * 10,
+			dataPoints: []DataPoint{},
 		}
 
-		window.init()
+		window.consolidate()
 
 		assert.Len(t, window.dataPoints, 10)
+		assert.Equal(t, uint32(0), window.dataPoints[0].Count)
+	})
+
+	t.Run("it fills gaps in the window", func(t *testing.T) {
+		now := time.Now().Truncate(time.Second)
+		window := slidingWindow{
+			resolution: time.Second,
+			length:     time.Second * 5,
+			dataPoints: []DataPoint{
+				{Timestamp: now.Add(time.Second * -4), Count: 1},
+				{Timestamp: now.Add(time.Second * -2), Count: 1},
+				{Timestamp: now, Count: 2},
+			},
+		}
+
+		window.consolidate()
+
+		require.Len(t, window.dataPoints, 5)
+		assert.Equal(t, uint32(1), window.dataPoints[0].Count)
+		assert.Equal(t, uint32(0), window.dataPoints[1].Count)
+		assert.Equal(t, uint32(1), window.dataPoints[2].Count)
+		assert.Equal(t, uint32(0), window.dataPoints[3].Count)
+		assert.Equal(t, uint32(2), window.dataPoints[4].Count)
 	})
 }
 
-func TestSlidingWindow_start(t *testing.T) {
-	t.Run("slides periodically", func(t *testing.T) {
+func TestSlidingWindow_Start(t *testing.T) {
+	t.Run("slides & consolidates periodically", func(t *testing.T) {
 		window := slidingWindow{
 			resolution:       time.Second,
-			length:           time.Second,
+			length:           time.Second * 5,
 			evictionInterval: time.Millisecond,
 			dataPoints: []DataPoint{
-				{Timestamp: time.Now().Truncate(time.Second).Add(-2 * time.Second), Count: 1},
+				{Timestamp: time.Now().Truncate(time.Second).Add(-5 * time.Second), Count: 2},
+				{Timestamp: time.Now().Truncate(time.Second).Add(-4 * time.Second), Count: 1},
 			},
 		}
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		window.start(ctx)
+		window.Start(ctx)
 
 		time.Sleep(time.Millisecond * 10)
 
-		assert.Len(t, window.dataPoints, 1)
-		assert.Equal(t, uint32(0), window.dataPoints[0].Count)
+		window.mutex.Lock()
+		defer window.mutex.Unlock()
+
+		require.Len(t, window.dataPoints, 5)
+		assert.Equal(t, uint32(1), window.dataPoints[0].Count)
 	})
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -28,6 +28,7 @@ import (
 	"nuts-foundation/nuts-monitor/client"
 	"nuts-foundation/nuts-monitor/client/diagnostics"
 	"nuts-foundation/nuts-monitor/client/network"
+	"nuts-foundation/nuts-monitor/config"
 	"nuts-foundation/nuts-monitor/test"
 	"os"
 	"testing"
@@ -116,7 +117,8 @@ func TestNetworkTopology(t *testing.T) {
 }
 
 func startServer(t *testing.T) int {
-	e := newEchoServer()
+	cfg := config.LoadConfig()
+	e := newEchoServer(cfg, nil)
 
 	httpPort := test.FreeTCPPort()
 

--- a/main.go
+++ b/main.go
@@ -80,8 +80,8 @@ func loadHistory(store *data.Store, c config.Config) {
 			break
 		}
 		// the transactions need to be converted from string to Transaction
-		for _, stringTransactions := range transactions {
-			transaction, err := data.FromJWS(stringTransactions)
+		for _, stringTransaction := range transactions {
+			transaction, err := data.FromJWS(stringTransaction)
 			if err != nil {
 				log.Printf("failed to parse transaction: %s", err)
 			}

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@
 package main
 
 import (
+	"context"
 	"embed"
 	"fmt"
 	"io/fs"
@@ -27,6 +28,7 @@ import (
 	"nuts-foundation/nuts-monitor/api"
 	"nuts-foundation/nuts-monitor/client"
 	"nuts-foundation/nuts-monitor/config"
+	"nuts-foundation/nuts-monitor/data"
 	"os"
 	"path"
 
@@ -40,17 +42,57 @@ const assetPath = "web"
 var embeddedFiles embed.FS
 
 func main() {
-	e := newEchoServer()
+	// first load the config
+	config := config.LoadConfig()
+	config.Print(log.Writer())
+
+	// then initialize the data storage and fill it with the initial transactions
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	store := data.NewStore()
+	loadHistory(store, config)
+	store.Start(ctx)
+
+	// start the web server
+	e := newEchoServer(config, store)
 
 	// Start server
 	e.Logger.Fatal(e.Start(fmt.Sprintf(":%d", 1313)))
 }
 
-func newEchoServer() *echo.Echo {
-	// config
-	config := config.LoadConfig()
-	config.Print(log.Writer())
+// loadHistory requests transactions from the Nuts node per 100 and stores them in the data store
+func loadHistory(store *data.Store, c config.Config) {
+	// initialize the client
+	client := client.HTTPClient{
+		Config: c,
+	}
 
+	// load the initial transactions
+	// ListTransactions per batch of 100, stop if the list is empty
+	// currentOffset is used to determine the offset for the next batch
+	currentOffset := 0
+	for {
+		transactions, err := client.ListTransactions(context.Background(), currentOffset, currentOffset+100)
+		if err != nil {
+			log.Fatalf("failed to load historic transactions: %s", err)
+		}
+		if len(transactions) == 0 {
+			break
+		}
+		// the transactions need to be converted from string to Transaction
+		for _, stringTransactions := range transactions {
+			transaction, err := data.FromJWS(stringTransactions)
+			if err != nil {
+				log.Printf("failed to parse transaction: %s", err)
+			}
+			store.Add(*transaction)
+		}
+		// increase offset for next batch
+		currentOffset += 100
+	}
+}
+
+func newEchoServer(config config.Config, store *data.Store) *echo.Echo {
 	// http server
 	e := echo.New()
 	e.HideBanner = true
@@ -68,6 +110,7 @@ func newEchoServer() *echo.Echo {
 		Client: client.HTTPClient{
 			Config: config,
 		},
+		DataStore: store,
 	}
 	api.RegisterHandlers(e, api.NewStrictHandler(apiWrapper, []api.StrictMiddlewareFunc{}))
 

--- a/web/src/admin/AdminApp.vue
+++ b/web/src/admin/AdminApp.vue
@@ -26,7 +26,6 @@
         <div class="px-3 mt-6">
           <div class="grid grid-cols-1">
             <router-link
-                id="vendor-menu-link"
                 :to="{name: 'admin.diagnostics'}"
                 active-class="menu-link-active"
                 class="menu-link">
@@ -49,7 +48,6 @@
               Diagnostics
             </router-link>
             <router-link
-                id="vendor-menu-link"
                 :to="{name: 'admin.network_topology'}"
                 active-class="menu-link-active"
                 class="menu-link">
@@ -60,6 +58,18 @@
               </div>
 
               NetworkTopology
+            </router-link>
+            <router-link
+                :to="{name: 'admin.transactions'}"
+                active-class="menu-link-active"
+                class="menu-link">
+              <div class="w-5 h-5 mr-3">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z" />
+                </svg>
+              </div>
+
+              Transactions
             </router-link>
           </div>
         </div>

--- a/web/src/admin/Transactions.vue
+++ b/web/src/admin/Transactions.vue
@@ -1,0 +1,161 @@
+<template>
+  <div>
+    <div class="my-2">
+      <div class="text-xl font-semibold text-gray-700 mb-2">Network</div>
+      <div class="grid grid-cols-1 md:grid-cols-1 lg:grid-cols-3 gap-4">
+        <div class="bg-white shadow rounded-lg p-4">
+          <div class="font-semibold text-gray-700 mb-2">Last hour</div>
+          <div id="viz_hour"></div>
+        </div>
+        <div class="bg-white shadow rounded-lg p-4">
+          <div class="font-semibold text-gray-700 mb-2">Last day</div>
+          <div id="viz_day"></div>
+        </div>
+        <div class="bg-white shadow rounded-lg p-4">
+          <div class="font-semibold text-gray-700 mb-2">Last month</div>
+          <div id="viz_month"></div>
+        </div>
+      </div>
+      <hr class="border-gray-300 my-2">
+
+    </div>
+    <router-view name="modal" @statusUpdate="updateStatus"></router-view>
+  </div>
+</template>
+
+<script>
+import * as d3 from "d3";
+export default {
+  data () {
+    return {
+      'aggregatedTransactions': {
+        'hourly': [],
+        'daily': [],
+        'monthly': []
+      }
+    }
+  },
+  created () {
+    // watch the params of the route to fetch the data again
+    this.$watch(
+        () => this.$route.params,
+        () => {
+          this.fetchData()
+        },
+        // fetch the data when the view is created and the data is
+        // already being observed
+        { immediate: true }
+    )
+  },
+  emits: ['statusUpdate'],
+  watch: {},
+  methods: {
+    updateStatus (event) {
+      this.$emit('statusUpdate', event)
+    },
+    fetchData () {
+      this.feedbackMsg = ''
+
+      this.$api.get('web/transactions/aggregated')
+          .then(responseData => {
+            this.aggregatedTransactions = responseData
+            this.updateGraphs(responseData)
+          })
+          .catch(reason => {
+            console.log('error while fetching data: ', reason)
+          })
+    },
+    updateGraphs(responseData) {
+      this.updateGraph('#viz_hour', responseData.hourly, '%H:%M')
+      this.updateGraph('#viz_day', responseData.daily, '%H:%M')
+      this.updateGraph('#viz_month', responseData.monthly,'%m-%d')
+    },
+    updateGraph(element, data, timeFormat) {
+      console.log('updateGraph', element, data)
+
+      // set the dimensions and margins of the graph
+      const margin = {top: 20, right: 20, bottom: 30, left: 30},
+          width = 600 - margin.left - margin.right,
+          height = 300 - margin.top - margin.bottom;
+
+      // Compute values.
+      const X = d3.map(data, (d) => new Date(d.timestamp * 1000));
+      const Y = d3.map(data, (d) => d.value);
+      const Z = d3.map(data, () => 1);
+
+      const xDomain = d3.extent(X);
+      let zDomain = Z;
+      zDomain = new d3.InternSet(zDomain);
+
+      // Omit any data not present in the z-domain.
+      const I = d3.range(X.length).filter(i => zDomain.has(Z[i]));
+
+      // Compute a nested array of series where each series is [[y1, y2], [y1, y2],
+      // [y1, y2], …] representing the y-extent of each stacked rect. In addition,
+      // each tuple has an i (index) property so that we can refer back to the
+      // original data point (data[i]). This code assumes that there is only one
+      // data point for a given unique x- and z-value.
+      const series = d3.stack()
+          .keys(zDomain)
+          .value(([x, I], z) => Y[I.get(z)])
+          (d3.rollup(I, ([i]) => i, i => X[i], i => Z[i]))
+          .map(s => s.map(d => Object.assign(d, {i: d.data[1].get(s.key)})));
+
+      // Compute the default y-domain. Note: diverging stacks can be negative.
+      const yDomain = d3.extent(series.flat(2));
+
+      // Construct scales and axes.
+      const xRange = [margin.left, width - margin.right]
+      const yRange = [height - margin.bottom, margin.top]
+      const xScale = d3.scaleLinear(xDomain, xRange);
+      const yScale = d3.scaleLinear(yDomain, yRange);
+      const xFormat = d3.timeFormat(timeFormat);
+      const yFormat = d3.defaultFormat;
+      const color = d3.scaleOrdinal(zDomain, d3.schemeTableau10);
+      const xAxis = d3.axisBottom(xScale).tickFormat(xFormat).tickSizeOuter(0);
+      const yAxis = d3.axisLeft(yScale).ticks(height / 50, yFormat);
+
+      const area = d3.area()
+          .x(({i}) => xScale(X[i]))
+          .y0(([y1]) => yScale(y1))
+          .y1(([, y2]) => yScale(y2));
+
+      const svg = d3.select(element)
+          .append("svg")
+          .attr("width", width)
+          .attr("height", height)
+          .attr("viewBox", [0, 0, width, height])
+          .attr("style", "max-width: 100%; height: auto; height: intrinsic;");
+
+      svg.append("g")
+          .attr("transform", `translate(${margin.left},0)`)
+          .call(yAxis)
+          .call(g => g.select(".domain").remove())
+          .call(g => g.selectAll(".tick line").clone()
+              .attr("x2", width - margin.left - margin.right)
+              .attr("stroke-opacity", 0.1))
+          .call(g => g.append("text")
+              .attr("x", -margin.left)
+              .attr("y", 10)
+              .attr("fill", "currentColor")
+              .attr("text-anchor", "start")
+              .text("count"));
+
+      svg.append("g")
+          .selectAll("path")
+          .data(series)
+          .join("path")
+          .attr("fill", ([{i}]) => color(Z[i]))
+          .attr("d", area)
+          .append("title")
+          .text(([{i}]) => Z[i]);
+
+      svg.append("g")
+          .attr("transform", `translate(0,${height - margin.bottom})`)
+          .call(xAxis)
+          .selectAll("text")
+          .attr("transform", "rotate(-45),translate(-10,0)");
+    }
+  }
+}
+</script>

--- a/web/src/index.js
+++ b/web/src/index.js
@@ -7,6 +7,7 @@ import AdminApp from './admin/AdminApp.vue'
 import Diagnostics from './admin/Diagnostics.vue'
 import Logout from './Logout.vue'
 import NetworkTopology from './admin/NetworkTopology.vue'
+import Transactions from './admin/Transactions.vue'
 import NotFound from './NotFound.vue'
 
 // Vuetify
@@ -41,6 +42,11 @@ const routes = [
         path: 'network_topology',
         name: 'admin.network_topology',
         component: NetworkTopology
+      },
+      {
+        path: 'transactions',
+        name: 'admin.transactions',
+        component: Transactions
       }
     ],
     //meta: { requiresAuth: true }


### PR DESCRIPTION
part of #36 

this PR adds a page with three graphs showing transaction counts.

Next step is to show counts per type of transactions.
Then show a top 10 of DID controllers with the most transactions total.
Then connect Nats

<img width="882" alt="Screenshot 2023-05-25 at 19 20 27" src="https://github.com/nuts-foundation/nuts-monitor/assets/703298/3570c8f9-75fa-4213-88ea-8a7df32941ce">
