### PR TITLE
Set Peer.Certificate from peer diagnostics

### DIFF
--- a/client/network/generated.go
+++ b/client/network/generated.go
@@ -72,6 +72,15 @@ type EventSubscriber struct {
 
 // PeerDiagnostics Diagnostic information of a peer.
 type PeerDiagnostics struct {
+	// Address Peer's address. This is an IP if it is an inbound connection.
+	Address *string `json:"address,omitempty"`
+
+	// Certificate Peer's Certificate
+	Certificate *string `json:"certificate,omitempty"`
+
+	// NodeDID Peer's NodeDID
+	NodeDID *string `json:"nodeDID,omitempty"`
+
 	// Peers IDs of the peer's peers.
 	Peers *[]string `json:"peers,omitempty"`
 

--- a/web/src/admin/NetworkTopology.vue
+++ b/web/src/admin/NetworkTopology.vue
@@ -121,7 +121,7 @@ export default {
 <li><label for="peer_id">NodeDID:</label><span id="peer_id">${d.data.raw.node_did}</span></li>
 <li><label for="peer_id">Certificate:</label><span id="peer_id">${d.data.raw.cn}</span></li>
 <li><label for="peer_id">Contact name:</label><span id="peer_id">${d.data.raw.contact_name}</span></li>
-<li><label for="peer_id">Contacte phone:</label><span id="peer_id">${d.data.raw.contact_phone}</span></li>
+<li><label for="peer_id">Contact phone:</label><span id="peer_id">${d.data.raw.contact_phone}</span></li>
 <li><label for="peer_id">Contact email:</label><span id="peer_id">${d.data.raw.contact_email}</span></li>
 <li><label for="peer_id">Contact webaddress:</label><span id="peer_id">${d.data.raw.contact_web}</span></li>
 <li><label for="peer_id">Software ID:</label><span id="peer_id">${d.data.raw.software_id}</span></li>


### PR DESCRIPTION
By adding the certificate to the peer diagnostics it is no longer needed to connect to all the peers to get their certificate. It now also provides Certificates for anonymous (no nodeDID) inbound connections.

Some certificates on the dev/stable network have no CN set in the certificate. This makes it look as if the certificate is missing. Not sure if we need to do anything about this.