### PR TITLE
Stabilize feature-test docker startup

### DIFF
--- a/.github/workflows/npm-build.yaml
+++ b/.github/workflows/npm-build.yaml
@@ -30,4 +30,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Pull nuts-node image
+        run: docker pull nutsfoundation/nuts-node
       - run: make feature-test

--- a/.github/workflows/npm-build.yaml
+++ b/.github/workflows/npm-build.yaml
@@ -31,5 +31,5 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Pull nuts-node image
-        run: docker pull nutsfoundation/nuts-node
+        run: docker pull nutsfoundation/nuts-node:v5.4.25
       - run: make feature-test

--- a/e2e/bootstrap.js
+++ b/e2e/bootstrap.js
@@ -40,7 +40,7 @@ before (async () => {
         new Promise((resolve, reject) => {
             setTimeout(() => {
                 reject(new Error('Timed out waiting for Docker container to start'));
-            }, 5000);
+            }, 120000);
         })
     ]);
 

--- a/e2e/bootstrap.js
+++ b/e2e/bootstrap.js
@@ -15,7 +15,7 @@ const opts = {
 before (async () => {
     global.expect = expect;
     global.browser = await puppeteer.launch(opts);
-    const dockerProcess = process.spawn('docker',["run", "-p", "1323:1323", "-e", "NUTS_STRICTMODE=false", "-e", "NUTS_NETWORK_ENABLETLS=false", "-e", "NUTS_AUTH_CONTRACTVALIDATORS=dummy", "nutsfoundation/nuts-node"])
+    const dockerProcess = process.spawn('docker',["run", "-p", "1323:1323", "-e", "NUTS_STRICTMODE=false", "-e", "NUTS_NETWORK_ENABLETLS=false", "-e", "NUTS_AUTH_CONTRACTVALIDATORS=dummy", "nutsfoundation/nuts-node:v5.4.25"])
 
     // Wait for the container to output "STARTED" in its stdout
     await Promise.race([


### PR DESCRIPTION
## Problem

After #304 (Go CI bump + Puppeteer `--no-sandbox`), the `build (1.25, 19.6)` job still fails:

```
1 failing
Error: Timed out waiting for Docker container to start
```

The e2e `before` hook (`e2e/bootstrap.js`) starts a `nutsfoundation/nuts-node` container and waits for it to log `Started HTTP`. Two issues:

1. The untagged image now resolves to **v6**, whose startup config differs from v5 (the v5-era env flags no longer bring up the HTTP interface), so the container never binds `:1323` (hence the repeated `localhost:1323 connection refused`).
2. The wait was only 5s, and the image wasn't pre-pulled, so even a working image could time out on a fresh runner.

## Fix

- **Pin the image to `nutsfoundation/nuts-node:v5.4.25`** (both the `docker run` and the CI pre-pull) so startup matches what the test expects.
- Pre-pull the image in CI so the test isn't racing an image download.
- Raise the container-start wait from 5s to 120s.

Assisted by AI